### PR TITLE
To Ignore node modules file push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
Node modules file may create the size limit problem of the repository. So using .gitignore file we can ignore the node_modules push on Github.